### PR TITLE
Update CoreWeave URL to include region code

### DIFF
--- a/coreweave.php
+++ b/coreweave.php
@@ -9,7 +9,7 @@ ob_start();
         let cache_buster = "cache_buster=" + (+Date.now());
 
         let code = regions[region_id].code.toLowerCase();
-        return `https://http.speedtest.las1.coreweave.com/ping?${cache_buster}`;
+        return `https://http.speedtest.${code}.coreweave.com/ping?${cache_buster}`;
 
         // https://http.speedtest.ord1.coreweave.com/ping
 


### PR DESCRIPTION
This fixes an issue identified in #45 regarding the CoreWeave URL's being pinged accidentally not using the correct region code.

![image](https://github.com/user-attachments/assets/e76d56e5-8c0f-48ec-a83f-de7b06d1d5c8)
